### PR TITLE
Download page

### DIFF
--- a/api/src/api/docs/index.ts
+++ b/api/src/api/docs/index.ts
@@ -129,11 +129,6 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   }
   categoriesEtag = `W/"${catHash.digest('base64')}"`;
 
-  fastify.get('/installation', (_request: FastifyRequest, reply: FastifyReply) => {
-    reply.header('cache-control', `public, max-age=${CACHE_HEADER}`)
-    return getRemoteDocument('https://raw.githubusercontent.com/wiki/replugged-org/replugged/Installation.md');
-  });
-
   fastify.get('/categories', listCategories);
   fastify.get('/:category/:document', getDocument);
 }

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -2,8 +2,8 @@
 import { h } from 'preact';
 import { lazy, Suspense } from 'preact/compat';
 import { useTitleTemplate, useMeta } from 'hoofd/preact';
-import { useCallback, useMemo } from 'preact/hooks';
-import Router, { Route } from 'preact-router';
+import { useCallback, useEffect, useMemo } from 'preact/hooks';
+import Router, { route, Route } from 'preact-router';
 
 import UserContext, { type User } from './UserContext';
 import Spinner from './util/Spinner';
@@ -41,6 +41,14 @@ type AppProps = {
   ctx?: Record<string, any>
 }
 
+function Redirect ({ to }: {path: string, to: string}) {
+  useEffect(() => {
+    route(to, true);
+  }, [ to ]);
+
+  return null;
+}
+
 export default function App (props: AppProps) {
   const change = useCallback(() => typeof document !== 'undefined' && document.getElementById('app')?.scrollTo(0, 0), []);
   const loading = useMemo(() => (
@@ -67,6 +75,7 @@ export default function App (props: AppProps) {
         <Router url={props?.url} onChange={change}>
           <Route path={Routes.HOME} component={Homepage} />
           <Route path={Routes.DOWNLOAD} component={Download} />
+          <Redirect path='/installation' to={Routes.DOWNLOAD} />
           <Route path={Routes.ME} component={AuthBoundary}>
             <Account />
           </Route>

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -14,6 +14,7 @@ import Footer from './layout/Footer';
 import Homepage from './Homepage';
 import Account from './account/Account';
 import Contributors from './Contributors';
+import Download from './Download';
 import Stats from './stats/Community';
 import Branding from './Branding';
 import Install from './Install';
@@ -65,6 +66,7 @@ export default function App (props: AppProps) {
       <Suspense fallback={loading}>
         <Router url={props?.url} onChange={change}>
           <Route path={Routes.HOME} component={Homepage} />
+          <Route path={Routes.DOWNLOAD} component={Download} />
           <Route path={Routes.ME} component={AuthBoundary}>
             <Account />
           </Route>
@@ -81,7 +83,6 @@ export default function App (props: AppProps) {
           </Route>
 
           <Route path={Routes.FAQ} component={Markdown} document='faq' />
-          <Route path={Routes.INSTALLATION} component={Markdown} document='installation' />
           <Route path={Routes.GUIDELINES} component={Markdown} document='guidelines' />
 
           <Route path={Routes.TERMS} component={Terms} />

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -40,6 +40,9 @@ const operatingSystems: OperatingSystemData[] = [ {
   os: 'macos',
   detect: () => platform.includes('mac'),
   name: 'macOS',
+  warning: <>
+    If you get a warning that the app can't be opened, right click on the app and select "Open". See <a href="https://support.apple.com/guide/mac-help/apple-cant-check-app-for-malicious-software-mchleab3a043/mac" target="_blank">this article</a> from Apple for more information.
+  </>,
   files: [ {
     label: 'Download for Intel',
     file: 'replugged-installer-macos.zip'
@@ -52,7 +55,7 @@ const operatingSystems: OperatingSystemData[] = [ {
   detect: () => platform.includes('linux'),
   name: 'Linux',
   warning: <>
-    Not all Linux distributions are supported. If the installer is not able to find your installation or you are using Flatpak, please follow the <a href="#manual">manual installation instructions</a>.
+    If the installer is not able to find your installation or you are using Flatpak, please follow the <a href="#manual">manual installation instructions</a>.
   </>,
   files: [ {
     label: 'Download for x86',

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -32,6 +32,9 @@ const operatingSystems: OperatingSystemData[] = [ {
   os: 'windows',
   detect: () => platform.includes('win'),
   name: 'Windows',
+  warning: <>
+    If you get a warning that the app can't be opened, click "Run Anyways". You may need to click "more info" to see this option.
+  </>,
   files: [ {
     label: 'Download',
     file: 'replugged-installer-windows.exe'

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -4,7 +4,11 @@ import { useTitleTemplate } from 'hoofd/preact';
 
 import style from './download.module.css';
 import sharedStyle from './shared.module.css';
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
+import Clipboard from 'feather-icons/dist/icons/clipboard.svg';
+import Check from 'feather-icons/dist/icons/check.svg';
+import { Routes } from '../constants';
+
 
 const DOWNLOAD_URL_BASE =  'https://github.com/replugged-org/electron-installer/releases/latest/download/';
 
@@ -61,14 +65,42 @@ const operatingSystems: OperatingSystemData[] = [ {
 
 const defaultOS = (operatingSystems.find(os => os.detect()) || operatingSystems[0]).os;
 
+function Code ({ children }: { children: string }) {
+  const [ copied, setCopied ] = useState(false);
+
+  useEffect(() => {
+    if (copied) {
+      const timeout = setTimeout(() => setCopied(false), 1500);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [ copied ]);
+
+  return (
+    <div className={style.codeContainer}>
+      <code className={style.code}>
+        {children}
+      </code>
+      <button
+        className={style.copyButton}
+        onClick={() => {
+          navigator.clipboard.writeText(children);
+          setCopied(true);
+        }}
+      >
+        {/* @ts-ignore */}
+        {copied ? <Check className={`${sharedStyle.icon} ${style.copyCheck}`} /> : <Clipboard className={sharedStyle.icon} />}
+      </button>
+    </div>
+  );
+}
+
 export default function Homepage () {
   useTitleTemplate('Replugged');
 
   const [ selectedOS, setSelectedOS ] = useState<OperatingSystems>(defaultOS);
 
   const selectedOSData = operatingSystems.find(os => os.os === selectedOS)!;
-
-  // TODO: manual installation instructions
 
   return (
     <main className={style.container}>
@@ -105,6 +137,43 @@ export default function Homepage () {
             )}
           </div>
         </div>
+      </div>
+      <div className={style.wrapper} >
+        <section id="manual" className={style.manual}>
+          <h2>Manual Installation</h2>
+          <h3>Prerequisites</h3>
+          <p>
+            <ul>
+              <li><a href="https://git-scm.com/downloads" target="_blank">Git</a></li>
+              <li><a href="https://nodejs.org/en/" target="_blank">Node.js</a></li>
+              <li><a href="https://pnpm.io/installation" target="_blank">pnpm</a>: <Code>npm install -g pnpm</Code></li>
+              <li><a href="https://discord.com/download" target="_blank">Discord</a></li>
+            </ul>
+          </p>
+          <h3>Installation</h3>
+          <p>
+            <ol>
+              <li>Clone the repository: <Code>git clone https://github.com/replugged-org/replugged</Code></li>
+              <li><code>cd</code> into the repository: <Code>cd replugged</Code></li>
+              <li>Install dependencies: <Code>pnpm i</Code></li>
+              <li>Build Replugged: <Code>pnpm run bundle</Code></li>
+              <li>Fully quit Discord</li>
+              <li>Plug into Discord: <Code>pnpm run plug --production</Code>
+                <br />
+                If you want to specify into a specific Discord version, you can add the platform as an argument: <Code>pnpm run plug --production [stable|ptb|canary|development]</Code>
+              </li>
+              <li>Reopen Discord</li>
+            </ol>
+            You can verify it's installed by going into Discord settings and looking for the "Replugged" tab.
+          </p>
+          <h3>Troubleshooting</h3>
+          <p>
+            If you're having issues, please reinstall Discord and try steps 4-6 again.
+            <br />
+            <br />
+            Still having issues? Please <a href={Routes.DICKSWORD} target="_blank">join our Discord</a> and create a thread in <a href="https://discord.com/channels/1000926524452647132/1006383180309352538" target="_blank">#support</a> with any errors you're getting and any other information you think might be helpful.
+          </p>
+        </section>
       </div>
     </main>
   );

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -3,6 +3,7 @@ import { h, JSX } from 'preact';
 import { useTitleTemplate } from 'hoofd/preact';
 
 import style from './download.module.css';
+import sharedStyle from './shared.module.css';
 import { useState } from 'preact/hooks';
 
 const DOWNLOAD_URL_BASE =  'https://github.com/replugged-org/electron-installer/releases/latest/download/';
@@ -50,7 +51,7 @@ const operatingSystems: OperatingSystemData[] = [ {
     Not all Linux distributions are supported. If the installer is not able to find your installation or you are using Flatpak, please follow the <a href="#manual">manual installation instructions</a>.
   </>,
   files: [ {
-    label: 'Download for x86_64',
+    label: 'Download for x86',
     file: 'replugged-installer-linux.AppImage'
   }, {
     label: 'Download for arm64',
@@ -67,41 +68,42 @@ export default function Homepage () {
 
   const selectedOSData = operatingSystems.find(os => os.os === selectedOS)!;
 
-  // TODO: styles for tabs, buttons, warning
   // TODO: manual installation instructions
 
   return (
     <main className={style.container}>
       <div className={style.heading}>
         <div className={style.wrapper}>
-          <h1 className={style.title}>Powerful and simple Discord client mod</h1>
-          <p className={style.motto}>Enhance your Discord experience with new features and looks. Make your Discord truly yours.</p>
-          <div className={style.tabs}>
-            {operatingSystems.map(os => (
-              <button
-                className={`${style.tab} ${os.os === selectedOS ? style.selected : ''}`}
-                onClick={() => setSelectedOS(os.os)}
-              >
-                {os.name}
-              </button>
-            ))}
-          </div>
-          <div className={style.buttons}>
-            {selectedOSData.files.map(file => (
-              <a
-                className={style.button}
-                href={`${DOWNLOAD_URL_BASE}/${file.file}`}
-                download
-              >
-                {file.label}
-              </a>
-            ))}
-          </div>
-          {selectedOSData.warning && (
-            <div className={style.warning}>
-              {selectedOSData.warning}
+          <h1 className={style.title}>Download Replugged</h1>
+          <div className={style.downloadContainer}>
+            <div className={style.tabs}>
+              {operatingSystems.map(os => (
+                <button
+                  className={`${style.tab} ${sharedStyle.button} ${os.os === selectedOS ? style.selected : ''}`}
+                  onClick={() => setSelectedOS(os.os)}
+                >
+                  {os.name}
+                </button>
+              ))}
             </div>
-          )}
+            <div className={style.divider} />
+            <div className={style.buttons}>
+              {selectedOSData.files.map(file => (
+                <a
+                  className={sharedStyle.button}
+                  href={`${DOWNLOAD_URL_BASE}/${file.file}`}
+                  download
+                >
+                  {file.label}
+                </a>
+              ))}
+            </div>
+            {selectedOSData.warning && (
+              <div className={style.warning}>
+                {selectedOSData.warning}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </main>

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -1,0 +1,110 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { h, JSX } from 'preact';
+import { useTitleTemplate } from 'hoofd/preact';
+
+import style from './download.module.css';
+import { useState } from 'preact/hooks';
+
+const DOWNLOAD_URL_BASE =  'https://github.com/replugged-org/electron-installer/releases/latest/download/';
+
+type OperatingSystems = 'windows' | 'macos' | 'linux';
+
+interface OperatingSystemData {
+  os: OperatingSystems;
+  detect: () => boolean;
+  name: string;
+  warning?: string | JSX.Element;
+  files: {
+    label: string;
+    file: string;
+  }[]
+}
+
+// @ts-expect-error DOM types are out of date
+const platform: string = navigator.userAgentData?.platform.toLowerCase() || navigator.platform.toLowerCase();
+
+const operatingSystems: OperatingSystemData[] = [ {
+  os: 'windows',
+  detect: () => platform.includes('win'),
+  name: 'Windows',
+  files: [ {
+    label: 'Download',
+    file: 'replugged-installer-windows.exe'
+  } ]
+}, {
+  os: 'macos',
+  detect: () => platform.includes('mac'),
+  name: 'macOS',
+  files: [ {
+    label: 'Download for Intel',
+    file: 'replugged-installer-macos.dmg'
+  }, {
+    label: 'Download for Apple Silicon',
+    file: 'replugged-installer-macos-arm64.dmg'
+  } ]
+}, {
+  os: 'linux',
+  detect: () => platform.includes('linux'),
+  name: 'Linux',
+  warning: <>
+    Not all Linux distributions are supported. If the installer is not able to find your installation or you are using Flatpak, please follow the <a href="#manual">manual installation instructions</a>.
+  </>,
+  files: [ {
+    label: 'Download for x86_64',
+    file: 'replugged-installer-linux.AppImage'
+  }, {
+    label: 'Download for arm64',
+    file: 'replugged-installer-linux-arm64.AppImage'
+  } ]
+} ];
+
+const defaultOS = (operatingSystems.find(os => os.detect()) || operatingSystems[0]).os;
+
+export default function Homepage () {
+  useTitleTemplate('Replugged');
+
+  const [ selectedOS, setSelectedOS ] = useState<OperatingSystems>(defaultOS);
+
+  const selectedOSData = operatingSystems.find(os => os.os === selectedOS)!;
+
+  // TODO: styles for tabs, buttons, warning
+  // TODO: manual installation instructions
+
+  return (
+    <main className={style.container}>
+      <div className={style.heading}>
+        <div className={style.wrapper}>
+          <h1 className={style.title}>Powerful and simple Discord client mod</h1>
+          <p className={style.motto}>Enhance your Discord experience with new features and looks. Make your Discord truly yours.</p>
+          <div className={style.tabs}>
+            {operatingSystems.map(os => (
+              <button
+                className={`${style.tab} ${os.os === selectedOS ? style.selected : ''}`}
+                onClick={() => setSelectedOS(os.os)}
+              >
+                {os.name}
+              </button>
+            ))}
+          </div>
+          <div className={style.buttons}>
+            {selectedOSData.files.map(file => (
+              <a
+                className={style.button}
+                href={`${DOWNLOAD_URL_BASE}/${file.file}`}
+                download
+              >
+                {file.label}
+              </a>
+            ))}
+          </div>
+          {selectedOSData.warning && (
+            <div className={style.warning}>
+              {selectedOSData.warning}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -42,10 +42,10 @@ const operatingSystems: OperatingSystemData[] = [ {
   name: 'macOS',
   files: [ {
     label: 'Download for Intel',
-    file: 'replugged-installer-macos.dmg'
+    file: 'replugged-installer-macos.zip'
   }, {
     label: 'Download for Apple Silicon',
-    file: 'replugged-installer-macos-arm64.dmg'
+    file: 'replugged-installer-macos-arm64.zip'
   } ]
 }, {
   os: 'linux',
@@ -124,6 +124,7 @@ export default function Homepage () {
                 <a
                   className={sharedStyle.button}
                   href={`${DOWNLOAD_URL_BASE}/${file.file}`}
+                  target="_blank"
                   download
                 >
                   {file.label}

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -10,7 +10,7 @@ import Check from 'feather-icons/dist/icons/check.svg';
 import { Routes } from '../constants';
 
 
-const DOWNLOAD_URL_BASE =  'https://github.com/replugged-org/electron-installer/releases/latest/download/';
+const DOWNLOAD_URL_BASE =  'https://github.com/replugged-org/electron-installer/releases/latest/download';
 
 type OperatingSystems = 'windows' | 'macos' | 'linux';
 

--- a/web/src/components/Download.tsx
+++ b/web/src/components/Download.tsx
@@ -172,7 +172,7 @@ export default function Homepage () {
           </p>
           <h3>Troubleshooting</h3>
           <p>
-            If you're having issues, please reinstall Discord and try steps 4-6 again.
+            If you're having issues, please reinstall Discord and try steps 5-7 again.
             <br />
             <br />
             Still having issues? Please <a href={Routes.DICKSWORD} target="_blank">join our Discord</a> and create a thread in <a href="https://discord.com/channels/1000926524452647132/1006383180309352538" target="_blank">#support</a> with any errors you're getting and any other information you think might be helpful.

--- a/web/src/components/Homepage.tsx
+++ b/web/src/components/Homepage.tsx
@@ -54,10 +54,10 @@ export default function Homepage () {
           <h1 className={style.title}>Powerful and simple Discord client mod</h1>
           <p className={style.motto}>Enhance your Discord experience with new features and looks. Make your Discord truly yours.</p>
           <div className={style.buttons}>
-            <a href={Routes.INSTALLATION} className={sharedStyle.button}>
+            <a href={Routes.DOWNLOAD} className={sharedStyle.button}>
               {/* @ts-ignore */}
               <Zap className={sharedStyle.icon} />
-              <span>Installation</span>
+              <span>Download</span>
             </a>
             <a href={Routes.DICKSWORD} className={sharedStyle.buttonLink}>
               {/* @ts-ignore */}
@@ -144,10 +144,10 @@ export default function Homepage () {
                         Stop limiting yourself to what Discord gives you. Get Replugged!
           </p>
           <div className={sharedStyle.buttons}>
-            <a href={Routes.INSTALLATION} className={sharedStyle.button}>
+            <a href={Routes.DOWNLOAD} className={sharedStyle.button}>
               {/* @ts-ignore */}
               <Zap className={sharedStyle.icon} />
-              <span>Installation</span>
+              <span>Download</span>
             </a>
             <a href={Routes.DICKSWORD} className={sharedStyle.buttonLink}>
               {/* @ts-ignore */}

--- a/web/src/components/Install.tsx
+++ b/web/src/components/Install.tsx
@@ -94,10 +94,10 @@ export default function InstallPage ({ matches: data }: Props) {
                 Please make sure Discord is open with the latest version of Replugged installed and try again.
                 <br />
                 <div className={styles.buttons}>
-                  <a href={Routes.INSTALLATION} className={sharedStyle.button}>
+                  <a href={Routes.DOWNLOAD} className={sharedStyle.button}>
                     {/* @ts-ignore */}
                     <Zap className={sharedStyle.icon} />
-                    <span>Install Replugged</span>
+                    <span>Download Replugged</span>
                   </a>
                   <a onClick={() => makeRequest()} className={sharedStyle['button-link']}>
                     <span>Try again</span>

--- a/web/src/components/download.module.css
+++ b/web/src/components/download.module.css
@@ -23,3 +23,42 @@
 	position: relative;
 	z-index: 2;
 }
+
+.downloadContainer {
+	background-color: var(--background-light);
+	margin: 10px auto;
+	padding: 10px;
+	border-radius: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.tabs {
+	display: flex;
+	gap: 10px;
+	justify-content: center;
+}
+
+.tab:not(.selected) {
+	background-color: var(--background-secondary);
+}
+
+.divider {
+	width: 100%;
+	height: 1px;
+	background-color: var(--text-color);
+}
+
+.buttons {
+	display: flex;
+	gap: 10px;
+	justify-content: center;
+}
+
+.warning {
+	border: 1px solid rgba(240, 178, 50, 1);
+	border-radius: 5px;
+	padding: 10px;
+	background-color: rgba(240, 178, 50, 0.1);
+}

--- a/web/src/components/download.module.css
+++ b/web/src/components/download.module.css
@@ -28,6 +28,11 @@
 
 .downloadContainer {
 	background-color: var(--background-light);
+	width: -webkit-fit-content;
+	width: -moz-fit-content;
+	width: fit-content;
+	min-width: min(100%, 500px);
+	max-width: min(100%, 800px);
 	margin: 10px auto;
 	padding: 10px;
 	border-radius: 10px;
@@ -47,7 +52,8 @@
 }
 
 .divider {
-	width: 100%;
+	width: 75%;
+	margin: 0 auto;
 	height: 1px;
 	background-color: var(--text-color);
 }

--- a/web/src/components/download.module.css
+++ b/web/src/components/download.module.css
@@ -1,5 +1,6 @@
 .container {
-	margin: 0;
+	margin: 0px;
+	margin-bottom: 20px;
 	padding: 0;
 	max-width: none;
 }
@@ -16,6 +17,7 @@
 	text-align: center;
 	background-color: var(--background-secondary);
 	position: relative;
+	margin-bottom: 20px;
 }
 
 .title {
@@ -61,4 +63,33 @@
 	border-radius: 5px;
 	padding: 10px;
 	background-color: rgba(240, 178, 50, 0.1);
+}
+
+.manual h2 {
+	margin-bottom: 20px;
+}
+
+.manual p {
+	margin: 16px 0px;
+}
+
+.codeContainer {
+	display: inline-flex;
+	align-items: center;
+	margin: 3px 0;
+}
+
+.code {
+	background-color: var(--background-secondary);
+	border-radius: 5px;
+	padding: 3px;
+}
+
+.copyButton {
+	display: inline-flex;
+	margin-left: 3px;
+}
+
+.copyCheck {
+	color: var(--green);
 }

--- a/web/src/components/download.module.css
+++ b/web/src/components/download.module.css
@@ -59,6 +59,10 @@
 }
 
 .warning {
+	width: -webkit-fit-content;
+	width: -moz-fit-content;
+	width: fit-content;
+	margin: 0 auto;
 	border: 1px solid rgba(240, 178, 50, 1);
 	border-radius: 5px;
 	padding: 10px;

--- a/web/src/components/download.module.css
+++ b/web/src/components/download.module.css
@@ -1,0 +1,25 @@
+.container {
+	margin: 0;
+	padding: 0;
+	max-width: none;
+}
+
+.wrapper {
+	margin: 0 auto;
+	max-width: 1300px;
+	padding: 0 2em;
+	width: 100%;
+}
+
+.heading {
+	padding: 32px 0;
+	text-align: center;
+	background-color: var(--background-secondary);
+	position: relative;
+}
+
+.title {
+	margin-bottom: 8px;
+	position: relative;
+	z-index: 2;
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -61,7 +61,7 @@ export default function Header () {
       </a>
 
       <nav className={style.nav}>
-        <a className={style.navLink} href={Routes.INSTALLATION}>Installation</a>
+        <a className={style.navLink} href={Routes.DOWNLOAD}>Download</a>
         <a className={style.navLink} href={Routes.STORE}>Store</a>
         <a className={style.navLink} href={Routes.CONTRIBUTORS}>Contributors</a>
         <a className={style.navLink} href={Routes.DICKSWORD} target='_blank' rel='noreferrer'>Discord Server</a>

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -46,6 +46,7 @@ export const Routes = {
   BRANDING: '/branding',
   INSTALL: '/install',
   FAQ: '/faq',
+  DOWNLOAD: '/download',
 
   STORE: '/store',
   STORE_PLUGINS: '/store/plugins',
@@ -62,7 +63,6 @@ export const Routes = {
   DOCS_ITEM: (cat: string, doc: string) => `/docs/${cat}/${doc}`,
   DOCS_GITHUB: 'https://github.com/replugged-org/documentation',
   GUIDELINES: '/guidelines',
-  INSTALLATION: '/installation',
   PORKORD_LICENSE: '/porkord-license',
   TERMS: '/legal/tos',
   PRIVACY: '/legal/privacy',


### PR DESCRIPTION
Adds download page with GUI installer to replace the previous installation page. The path is changed to `/download` but the old URL will redirect. Manual installation instructions have been moved to this page as well.