### PR TITLE
Track stats for addon install/update

### DIFF
--- a/api/src/api/store/items.ts
+++ b/api/src/api/store/items.ts
@@ -119,7 +119,7 @@ export default function (fastify: FastifyInstance, _: unknown, done: () => void)
     }
 
     const { type, version } = request.query;
-    if (type && ["update", "install"].includes(type) && version) {
+    if (type && ["update", "install"].includes(type)) {
       const collection = fastify.mongo.db!.collection<StoreStats>("storeStats");
 
       // Will be used to make sure someone can't inflate their stats by sending a bunch of requests

--- a/api/src/config.example.ts
+++ b/api/src/config.example.ts
@@ -21,6 +21,7 @@ export default {
       donator: "1000955917237506130",
     },
   },
+  ipSalt: "", // Generate with "openssl rand -hex 32"
   github: {
     clientID: "",
     clientSecret: "",

--- a/types/store.d.ts
+++ b/types/store.d.ts
@@ -95,6 +95,6 @@ export interface StoreStats {
   id: string;
   date: Date;
   type: "install" | "update";
-  version: string;
+  version?: string;
   ipHash: string;
 }

--- a/types/store.d.ts
+++ b/types/store.d.ts
@@ -90,3 +90,11 @@ export type FormHosting = Form & {
 };
 
 export type StoreForm = FormPublish | FormVerification | FormHosting;
+
+export interface StoreStats {
+  id: string;
+  date: Date;
+  type: "install" | "update";
+  version: string;
+  ipHash: string;
+}


### PR DESCRIPTION
Query strings are implemented into the client in https://github.com/replugged-org/replugged/pull/532. We will save that information, the associated addon ID, the date, and a hash of the requesting IP address for deduping. The code to get all the data and display and all that is not done yet, but I'm adding the code to get the data now so that it will be available when we're ready to use it.