### PR TITLE
feat(store): add sorting by download count

### DIFF
--- a/web/src/components/store/Store.tsx
+++ b/web/src/components/store/Store.tsx
@@ -14,6 +14,7 @@ import { toArray } from "../util/misc";
 import { getError, installAddon, useInstalledAddons } from "./utils";
 import { Routes } from "../../constants";
 import { RouteError } from "../../types";
+import { SelectField } from "../util/Form";
 
 type StoreKind = "plugin" | "theme";
 
@@ -238,6 +239,8 @@ export function StandaloneStoreItem({
 export default function Store({ kind, installedAddons, updateAddonList }: StoreProps): VNode {
   useTitle(`Replugged ${LABELS[kind]}`);
 
+  const [sort, setSort] = useState("downloads");
+
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState(query);
 
@@ -252,12 +255,13 @@ export default function Store({ kind, installedAddons, updateAddonList }: StoreP
   );
 
   const itemsQuery = useInfiniteQuery<PaginatedStore>({
-    queryKey: ["store", kind, debouncedQuery],
+    queryKey: ["store", kind, debouncedQuery, sort],
     queryFn: async ({ pageParam: page }) => {
       const queryString = new URLSearchParams({
         page: page?.toString() ?? pageQuery ?? "1",
         items: (12).toString(),
         query: debouncedQuery,
+        sort,
       });
 
       const res = await fetch(`/api/store/list/${kind}?${queryString}`);
@@ -290,7 +294,17 @@ export default function Store({ kind, installedAddons, updateAddonList }: StoreP
   return (
     <main class={style.main}>
       <h1 class={style.header}>Replugged {LABELS[kind]}</h1>
-      <div class={style.grid}>
+      <div class={style.controls}>
+        <SelectField
+          fieldClassName={style.sortSelect}
+          name="sort"
+          label="Sort By"
+          options={[
+            { id: "downloads", name: "Downloads" },
+            { id: "name", name: "Name" },
+          ]}
+          onChange={(e) => setSort(e.currentTarget.value)}
+        />
         {items.length > 0 || debouncedQuery ? (
           <input
             class={`${formStyle.textField} ${style.search}`}
@@ -300,6 +314,8 @@ export default function Store({ kind, installedAddons, updateAddonList }: StoreP
             onInput={(e) => setQuery(e.currentTarget.value)}
           />
         ) : null}
+      </div>
+      <div class={style.grid}>
         <StoreBody
           {...itemsQuery}
           items={items}

--- a/web/src/components/store/Store.tsx
+++ b/web/src/components/store/Store.tsx
@@ -298,13 +298,14 @@ export default function Store({ kind, installedAddons, updateAddonList }: StoreP
         {items.length > 0 || debouncedQuery ? (
           <>
             <SelectField
-              fieldClassName={style.sortSelect}
               name="sort"
               label="Sort By"
               options={[
                 { id: "downloads", name: "Downloads" },
                 { id: "name", name: "Name" },
               ]}
+              value={sort}
+              fieldClassName={style.sortSelect}
               onChange={(e) => setSort(e.currentTarget.value)}
             />
             <input

--- a/web/src/components/store/Store.tsx
+++ b/web/src/components/store/Store.tsx
@@ -295,24 +295,26 @@ export default function Store({ kind, installedAddons, updateAddonList }: StoreP
     <main class={style.main}>
       <h1 class={style.header}>Replugged {LABELS[kind]}</h1>
       <div class={style.controls}>
-        <SelectField
-          fieldClassName={style.sortSelect}
-          name="sort"
-          label="Sort By"
-          options={[
-            { id: "downloads", name: "Downloads" },
-            { id: "name", name: "Name" },
-          ]}
-          onChange={(e) => setSort(e.currentTarget.value)}
-        />
         {items.length > 0 || debouncedQuery ? (
-          <input
-            class={`${formStyle.textField} ${style.search}`}
-            type="text"
-            placeholder="Search"
-            value={query}
-            onInput={(e) => setQuery(e.currentTarget.value)}
-          />
+          <>
+            <SelectField
+              fieldClassName={style.sortSelect}
+              name="sort"
+              label="Sort By"
+              options={[
+                { id: "downloads", name: "Downloads" },
+                { id: "name", name: "Name" },
+              ]}
+              onChange={(e) => setSort(e.currentTarget.value)}
+            />
+            <input
+              class={`${formStyle.textField} ${style.search}`}
+              type="text"
+              placeholder="Search"
+              value={query}
+              onInput={(e) => setQuery(e.currentTarget.value)}
+            />
+          </>
         ) : null}
       </div>
       <div class={style.grid}>

--- a/web/src/components/store/Store.tsx
+++ b/web/src/components/store/Store.tsx
@@ -294,7 +294,7 @@ export default function Store({ kind, installedAddons, updateAddonList }: StoreP
   return (
     <main class={style.main}>
       <h1 class={style.header}>Replugged {LABELS[kind]}</h1>
-      <div class={style.controls}>
+      <div class={style.grid}>
         {items.length > 0 || debouncedQuery ? (
           <>
             <SelectField
@@ -316,8 +316,6 @@ export default function Store({ kind, installedAddons, updateAddonList }: StoreP
             />
           </>
         ) : null}
-      </div>
-      <div class={style.grid}>
         <StoreBody
           {...itemsQuery}
           items={items}

--- a/web/src/components/store/store.module.css
+++ b/web/src/components/store/store.module.css
@@ -6,6 +6,24 @@
   margin-bottom: 24px;
 }
 
+.controls {
+  display: flex;
+  gap: 10px;
+  flex-direction: column;
+  margin-bottom: 24px;
+}
+
+.sortSelect {
+  flex: 0.25;
+  margin: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.search {
+  width: auto;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(1, 1fr);
@@ -16,16 +34,19 @@
   .grid {
     grid-template-columns: repeat(2, 1fr);
   }
+  .controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    flex-direction: row;
+    margin-bottom: 24px;
+  }
 }
 
 @media (min-width: 1024px) {
   .grid {
     grid-template-columns: repeat(3, 1fr);
   }
-}
-
-.search {
-  grid-column-end: -1;
 }
 
 .full-grid {

--- a/web/src/components/store/store.module.css
+++ b/web/src/components/store/store.module.css
@@ -6,22 +6,15 @@
   margin-bottom: 24px;
 }
 
-.controls {
-  display: flex;
-  gap: 10px;
-  flex-direction: column;
-  margin-bottom: 24px;
-}
-
 .sortSelect {
-  flex: 0.25;
   margin: 0;
   padding-bottom: 0;
   border-bottom: none;
 }
 
 .search {
-  width: auto;
+  grid-column-end: -1;
+  align-self: end;
 }
 
 .grid {
@@ -33,13 +26,6 @@
 @media (min-width: 768px) {
   .grid {
     grid-template-columns: repeat(2, 1fr);
-  }
-  .controls {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    flex-direction: row;
-    margin-bottom: 24px;
   }
 }
 

--- a/web/src/components/util/Form.tsx
+++ b/web/src/components/util/Form.tsx
@@ -1,6 +1,7 @@
 import {
   type Attributes,
   type ComponentChild,
+  type JSX,
   ComponentChildren,
   VNode,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -20,6 +21,7 @@ type BaseProps = Attributes & {
   error?: ComponentChild;
   children: ComponentChild;
   required?: boolean;
+  className?: string;
 };
 
 type BaseFieldProps = Attributes & {
@@ -31,6 +33,7 @@ type BaseFieldProps = Attributes & {
   disabled?: boolean;
   raw?: boolean;
   rk?: number; // [Cynthia] this is used to force re-render of form fields, to help with errors sometimes not showing up
+  fieldClassName?: string;
 };
 
 type TextFieldProps = BaseFieldProps & {
@@ -42,6 +45,7 @@ type TextFieldProps = BaseFieldProps & {
 };
 type CheckboxFieldProps = BaseFieldProps & { value?: boolean };
 type SelectFieldProps = BaseFieldProps & {
+  onChange: JSX.GenericEventHandler<HTMLSelectElement>;
   value?: string;
   options: Array<{ id: string; name: string }>;
 };
@@ -81,7 +85,7 @@ function useField(note?: ComponentChild, error?: ComponentChild, rk?: number): F
 
 function BaseField(props: BaseProps): VNode {
   return (
-    <div className={style.field}>
+    <div className={[style.field, props.className].filter(Boolean).join(" ")}>
       <label className={style.label} for={props.id}>
         {props.label}
         {props.required && <span className={style.required}>*</span>}
@@ -167,7 +171,7 @@ export function SelectField(props: SelectFieldProps): VNode {
   const field = useField(props.note, props.error, props.rk);
 
   return (
-    <BaseField {...field} label={props.label} required={props.required} id={field.id}>
+    <BaseField {...field} label={props.label} required={props.required} id={field.id} className={props.fieldClassName}>
       <select
         type="checkbox"
         id={field.id}
@@ -176,7 +180,8 @@ export function SelectField(props: SelectFieldProps): VNode {
         required={props.required}
         disabled={props.disabled}
         className={style.selectField}
-        onClick={field.onChange}>
+        onClick={field.onChange}
+        onChange={props.onChange}>
         {props.options.map(({ id, name }) => (
           <option key={id} value={id}>
             {name}

--- a/web/src/components/util/Form.tsx
+++ b/web/src/components/util/Form.tsx
@@ -171,7 +171,12 @@ export function SelectField(props: SelectFieldProps): VNode {
   const field = useField(props.note, props.error, props.rk);
 
   return (
-    <BaseField {...field} label={props.label} required={props.required} id={field.id} className={props.fieldClassName}>
+    <BaseField
+      {...field}
+      label={props.label}
+      required={props.required}
+      id={field.id}
+      className={props.fieldClassName}>
       <select
         type="checkbox"
         id={field.id}


### PR DESCRIPTION
- Added a dropdown to select how the addons should be sorted (by downloads, now default, or by name).
- Added a `sort` query to `/api/store/list/:type`: accepts `downloads` and `name` as sort types.

![image](https://github.com/replugged-org/replugged-backend/assets/38290480/c50b765f-a2a2-4e53-bce9-f3f777010606)
